### PR TITLE
Add functionality to check for event clashes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddEventCommand.java
@@ -42,6 +42,7 @@ public class AddEventCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New event added: %1$s";
     public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in the address book";
+    public static final String MESSAGE_CLASHING_EVENT = "This event clashes with another event in the address book";
 
     private final Event toAdd;
 
@@ -59,6 +60,10 @@ public class AddEventCommand extends Command {
 
         if (model.hasEvent(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_EVENT);
+        }
+
+        if (model.hasClashingEvent(toAdd)) {
+            throw new CommandException(MESSAGE_CLASHING_EVENT);
         }
 
         model.addEvent(toAdd);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -117,11 +117,20 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a clashing event with {@code event} exists in the address book.
+     */
+    public boolean hasClashingEvent(Event event) {
+        requireNonNull(event);
+        return events.containsClashingEvent(event);
+    }
+
+    /**
      * Adds an event to the address book.
      * The event must not already exist in the address book.
      */
     public void addEvent(Event event) {
         assert !hasEvent(event);
+        assert !hasClashingEvent(event);
 
         events.add(event);
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -53,6 +53,11 @@ public interface Model {
     boolean hasEvent(Event event);
 
     /**
+     * Returns true if a clashing event with {@code event} exists in the address book.
+     */
+    boolean hasClashingEvent(Event event);
+
+    /**
      * Adds the given event into the address book.
      * {@code event} must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -107,6 +107,12 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
+    public boolean hasClashingEvent(Event event) {
+        requireNonNull(event);
+        return versionedAddressBook.hasClashingEvent(event);
+    }
+
+    @Override
     public void addEvent(Event event) {
         versionedAddressBook.addEvent(event);
         updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -69,8 +69,9 @@ public class Event {
      * Returns true if the two events clash
      */
     public boolean isClashingEvent(Event event) {
-        //todo: implement method
-        return true;
+        return eventDate.equals(event.eventDate)
+                && eventEndTime.compareTo(event.eventStartTime) > 0
+                && eventStartTime.compareTo(event.eventEndTime) < 0;
     }
 
     //todo: check isSameEvent constraints

--- a/src/main/java/seedu/address/model/event/exceptions/EventClashException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/EventClashException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.event.exceptions;
+
+/**
+ * Signals that the operation will result in two clashing {@code Event}s (Events are considered clashing events if
+ * they clash, as defined in {@code Event#isClashingEvent(Event)}).
+ */
+public class EventClashException extends RuntimeException {
+    public EventClashException() {
+        super("Operation would result in clash events");
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -125,6 +125,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasClashingEvent(Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
@@ -67,6 +67,25 @@ public class AddEventCommandTest {
     }
 
     @Test
+    public void execute_clashingEvent_throwsCommandException() throws Exception {
+        Event validEvent = new ScheduledEventBuilder()
+                .withEventStartTime("1200")
+                .withEventEndTime("1400")
+                .build();
+        ModelStub modelStub = new ModelStubWithEvent(validEvent);
+
+        Event clashingEvent = new ScheduledEventBuilder()
+                .withEventStartTime("1210")
+                .withEventEndTime("1410")
+                .build();
+        AddEventCommand addEventCommand = new AddEventCommand(clashingEvent);
+
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(AddEventCommand.MESSAGE_CLASHING_EVENT);
+        addEventCommand.execute(modelStub, commandHistory);
+    }
+
+    @Test
     public void equals() {
         Event firstEvent = new ScheduledEventBuilder().withEventName("event").build();
         Event secondEvent = new ScheduledEventBuilder().withEventName("a different event").build();
@@ -123,6 +142,12 @@ public class AddEventCommandTest {
         public boolean hasEvent(Event event) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean hasClashingEvent(Event event) {
+            throw new AssertionError("This method should not be called.");
+        }
+
 
         @Override
         public void deletePerson(Person target) {
@@ -201,6 +226,12 @@ public class AddEventCommandTest {
             requireNonNull(event);
             return this.event.isSameEvent(event);
         }
+
+        @Override
+        public boolean hasClashingEvent(Event event) {
+            requireNonNull(event);
+            return this.event.isClashingEvent(event);
+        }
     }
 
     /**
@@ -213,6 +244,12 @@ public class AddEventCommandTest {
         public boolean hasEvent(Event event) {
             requireNonNull(event);
             return eventsAdded.stream().anyMatch(event::isSameEvent);
+        }
+
+        @Override
+        public boolean hasClashingEvent(Event event) {
+            requireNonNull(event);
+            return eventsAdded.stream().anyMatch(event::isClashingEvent);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -60,6 +60,9 @@ public class CommandTestUtil {
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     // Events
+    public static final String CLASHING_EVENT_START_TIME_DOCTORAPPT = "1410";
+    public static final String CLASHING_EVENT_END_TIME_DOCTORAPPT = "1440";
+
     public static final String VALID_EVENT_NAME_DOCTORAPPT = "Doctor appointment";
     public static final String VALID_EVENT_NAME_MEETING = "Meeting";
     public static final String VALID_EVENT_DESC_DOCTORAPPT = "Consultation";

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -3,6 +3,8 @@ package seedu.address.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.CLASHING_EVENT_END_TIME_DOCTORAPPT;
+import static seedu.address.logic.commands.CommandTestUtil.CLASHING_EVENT_START_TIME_DOCTORAPPT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.TypicalEvents.DOCTORAPPT;
@@ -22,6 +24,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.exceptions.DuplicateEventException;
+import seedu.address.model.event.exceptions.EventClashException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
@@ -83,6 +86,24 @@ public class AddressBookTest {
     }
 
     @Test
+    public void resetData_withClashingEvents_throwsDuplicateEventException() {
+
+        List<Person> newPersons = Arrays.asList(ALICE);
+
+        // Two events with the same identity fields
+        Event clashingEvent =
+                new ScheduledEventBuilder(DOCTORAPPT)
+                        .withEventStartTime(CLASHING_EVENT_START_TIME_DOCTORAPPT)
+                        .withEventEndTime(CLASHING_EVENT_END_TIME_DOCTORAPPT)
+                        .build();
+        List<Event> newEvents = Arrays.asList(DOCTORAPPT, clashingEvent);
+        AddressBookStub newData = new AddressBookStub(newPersons, newEvents);
+
+        thrown.expect(EventClashException.class);
+        addressBook.resetData(newData);
+    }
+
+    @Test
     public void hasPerson_nullPerson_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
         addressBook.hasPerson(null);
@@ -105,6 +126,11 @@ public class AddressBookTest {
     }
 
     @Test
+    public void hasClashingEvent_clashingEventNotInAddressBook_returnsFalse() {
+        assertFalse(addressBook.hasClashingEvent(DOCTORAPPT));
+    }
+
+    @Test
     public void hasPerson_personInAddressBook_returnsTrue() {
         addressBook.addPerson(ALICE);
         assertTrue(addressBook.hasPerson(ALICE));
@@ -114,6 +140,16 @@ public class AddressBookTest {
     public void hasEvent_eventInAddressBook_returnsTrue() {
         addressBook.addEvent(DOCTORAPPT);
         assertTrue(addressBook.hasEvent(DOCTORAPPT));
+    }
+
+    @Test
+    public void hasClashingEvent_clashingEventInAddressBook_returnsTrue() {
+        addressBook.addEvent(DOCTORAPPT);
+        Event clashingEvent = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime(CLASHING_EVENT_START_TIME_DOCTORAPPT)
+                .withEventEndTime(CLASHING_EVENT_END_TIME_DOCTORAPPT)
+                .build();
+        assertTrue(addressBook.hasClashingEvent(clashingEvent));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -2,6 +2,8 @@ package seedu.address.model;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.CLASHING_EVENT_END_TIME_DOCTORAPPT;
+import static seedu.address.logic.commands.CommandTestUtil.CLASHING_EVENT_START_TIME_DOCTORAPPT;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_EVENTS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalEvents.DOCTORAPPT;
@@ -16,6 +18,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.model.event.Event;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.ScheduledEventBuilder;
@@ -49,6 +52,11 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasClashingEvent_clashingEventNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasClashingEvent(DOCTORAPPT));
+    }
+
+    @Test
     public void hasPerson_personInAddressBook_returnsTrue() {
         modelManager.addPerson(ALICE);
         assertTrue(modelManager.hasPerson(ALICE));
@@ -58,6 +66,20 @@ public class ModelManagerTest {
     public void hasEvent_eventInAddressBook_returnsTrue() {
         modelManager.addEvent(DOCTORAPPT);
         assertTrue(modelManager.hasEvent(DOCTORAPPT));
+    }
+
+    @Test
+    public void hasClashingEvent_clashingEventInAddressBook_returnsTrue() {
+        modelManager.addEvent(DOCTORAPPT);
+        Event clashingEvent = new ScheduledEventBuilder()
+                .withEventName(DOCTORAPPT.getEventName().eventName)
+                .withEventDescription(DOCTORAPPT.getEventDescription().eventDescription)
+                .withEventDate(DOCTORAPPT.getEventDate().toString())
+                .withEventStartTime(CLASHING_EVENT_START_TIME_DOCTORAPPT)
+                .withEventEndTime(CLASHING_EVENT_END_TIME_DOCTORAPPT)
+                .withEventAddress(DOCTORAPPT.getEventAddress().eventAddress)
+                .build();
+        assertTrue(modelManager.hasClashingEvent(clashingEvent));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -14,6 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.testutil.Assert;
 import seedu.address.testutil.ScheduledEventBuilder;
 
 public class EventTest {
@@ -59,5 +60,103 @@ public class EventTest {
         // different address -> returns false
         editedDoctorAppt = new ScheduledEventBuilder(DOCTORAPPT).withEventAddress(VALID_EVENT_ADDRESS_MEETING).build();
         assertFalse(DOCTORAPPT.equals(editedDoctorAppt));
+    }
+
+    @Test
+    // checking for clashes between two Events
+    public void isClashingEvent() {
+
+        // same dates
+        Event event = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime("1200")
+                .withEventEndTime("1400")
+                .build();
+
+        // null
+        Assert.assertThrows(NullPointerException.class, () -> event.isClashingEvent(null));
+
+        // before event, no clash
+        Event earlierEventNoClash = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime("1000")
+                .withEventEndTime("1159")
+                .build();
+        assertFalse(event.isClashingEvent(earlierEventNoClash));
+
+        Event anotherEarlierEventNoClash = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime("1000")
+                .withEventEndTime("1200")
+                .build();
+        assertFalse(event.isClashingEvent(anotherEarlierEventNoClash));
+
+        // after event, no clash
+        Event laterEventNoClash = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime("1401")
+                .withEventEndTime("1500")
+                .build();
+        assertFalse(event.isClashingEvent(laterEventNoClash));
+
+        Event anotherLaterEventNoClash = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime("1400")
+                .withEventEndTime("1500")
+                .build();
+        assertFalse(event.isClashingEvent(anotherLaterEventNoClash));
+
+        // starts before event starts and ends after event starts, with clash
+        Event firstEventWithClash = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime("1100")
+                .withEventEndTime("1300")
+                .build();
+        assertTrue(event.isClashingEvent(firstEventWithClash));
+
+        // starts after event starts and ends before event ends, with clash
+        Event secondEventWithClash = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime("1230")
+                .withEventEndTime("1330")
+                .build();
+        assertTrue(event.isClashingEvent(secondEventWithClash));
+
+        // starts before event ends, ends after event ends, clash
+        Event thirdEventWithClash = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime("1300")
+                .withEventEndTime("1500")
+                .build();
+        assertTrue(event.isClashingEvent(thirdEventWithClash));
+
+        // covers whole duration of event and more, clash
+        Event fourthEventWithClash = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime("1100")
+                .withEventEndTime("1500")
+                .build();
+        assertTrue(event.isClashingEvent(fourthEventWithClash));
+
+        // same duration as event, clash
+        Event fifthEventWithClash = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime("1200")
+                .withEventEndTime("1400")
+                .build();
+        assertTrue(event.isClashingEvent(fifthEventWithClash));
+
+        // different dates
+        Event newEvent = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventDate("2018-09-01")
+                .withEventStartTime("1200")
+                .withEventEndTime("1400")
+                .build();
+
+        // different date, same time, no clash
+        Event differentDateSameTime = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventDate("2018-09-02")
+                .withEventStartTime("1200")
+                .withEventEndTime("1400")
+                .build();
+        assertFalse(event.isClashingEvent(differentDateSameTime));
+
+        // different date, different time, no clash
+        Event differentDateDifferentTime = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventDate("2018-09-02")
+                .withEventStartTime("1000")
+                .withEventEndTime("1200")
+                .build();
+        assertFalse(event.isClashingEvent(differentDateDifferentTime));
     }
 }

--- a/src/test/java/seedu/address/model/event/UniqueEventListTest.java
+++ b/src/test/java/seedu/address/model/event/UniqueEventListTest.java
@@ -3,6 +3,8 @@ package seedu.address.model.event;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.CLASHING_EVENT_END_TIME_DOCTORAPPT;
+import static seedu.address.logic.commands.CommandTestUtil.CLASHING_EVENT_START_TIME_DOCTORAPPT;
 import static seedu.address.testutil.TypicalEvents.DOCTORAPPT;
 import static seedu.address.testutil.TypicalEvents.MEETING;
 
@@ -15,6 +17,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.model.event.exceptions.DuplicateEventException;
+import seedu.address.model.event.exceptions.EventClashException;
+import seedu.address.testutil.ScheduledEventBuilder;
 
 public class UniqueEventListTest {
     @Rule
@@ -34,9 +38,24 @@ public class UniqueEventListTest {
     }
 
     @Test
+    public void contains_clashingEventNotInList_returnsFalse() {
+        assertFalse(uniqueEventList.containsClashingEvent(DOCTORAPPT));
+    }
+
+    @Test
     public void contains_eventInList_returnsTrue() {
         uniqueEventList.add(DOCTORAPPT);
         assertTrue(uniqueEventList.contains(DOCTORAPPT));
+    }
+
+    @Test
+    public void contains_clashingEventInList_returnsTrue() {
+        uniqueEventList.add(DOCTORAPPT);
+        Event clashingEvent = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime(CLASHING_EVENT_START_TIME_DOCTORAPPT)
+                .withEventEndTime(CLASHING_EVENT_END_TIME_DOCTORAPPT)
+                .build();
+        assertTrue(uniqueEventList.containsClashingEvent(clashingEvent));
     }
 
     @Test
@@ -88,6 +107,17 @@ public class UniqueEventListTest {
         List<Event> listWithDuplicateEvents = Arrays.asList(DOCTORAPPT, DOCTORAPPT);
         thrown.expect(DuplicateEventException.class);
         uniqueEventList.setEvents(listWithDuplicateEvents);
+    }
+
+    @Test
+    public void setEvents_listWithClashingEvents_throwsDuplicateEventException() {
+        Event clashingEvent = new ScheduledEventBuilder(DOCTORAPPT)
+                .withEventStartTime(CLASHING_EVENT_START_TIME_DOCTORAPPT)
+                .withEventEndTime(CLASHING_EVENT_END_TIME_DOCTORAPPT)
+                .build();
+        List<Event> listWithClashingEvents = Arrays.asList(DOCTORAPPT, clashingEvent);
+        thrown.expect(EventClashException.class);
+        uniqueEventList.setEvents(listWithClashingEvents);
     }
 
     @Test


### PR DESCRIPTION
- add `EventClashException` which is raised whenever an event clash is detected
- update addEvent commands in `Model`, `UniqueEventList` and `AddressBook` to check for clashes
- update `AddEventCommand#execute` to check for clashes
- add test cases for clashing events in the above

Resolves #96 