### PR TITLE
fix edit person bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -26,6 +26,7 @@ import seedu.address.model.person.Faculty;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -85,9 +86,14 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        model.updatePerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        model.commitAddressBook();
+        try {
+            model.updatePerson(personToEdit, editedPerson);
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            model.commitAddressBook();
+        } catch (DuplicatePersonException dpe) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -12,7 +12,7 @@ import seedu.address.commons.core.GuiSettings;
 public class UserPrefs {
 
     private GuiSettings guiSettings;
-    private Path addressBookFilePath = Paths.get("data" , "eventsPlus.xml");
+    private Path addressBookFilePath = Paths.get("data" , "eventsPlusPlus.xml");
 
     public UserPrefs() {
         setGuiSettings(500, 500, 0, 0, true, null);

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -12,7 +12,7 @@ import seedu.address.commons.core.GuiSettings;
 public class UserPrefs {
 
     private GuiSettings guiSettings;
-    private Path addressBookFilePath = Paths.get("data" , "eventsPlusPlus.xml");
+    private Path addressBookFilePath = Paths.get("data" , "eventsPlus+.xml");
 
     public UserPrefs() {
         setGuiSettings(500, 500, 0, 0, true, null);

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.event.exceptions.DuplicateEventException;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
@@ -61,6 +62,17 @@ public class UniquePersonList implements Iterable<Person> {
 
         if (!target.isSamePerson(editedPerson) && contains(editedPerson)) {
             throw new DuplicatePersonException();
+        }
+
+        /** TODO:
+         * temp fix for bug where editedPerson is the same person as target, but also same person
+         * as another person in the address book.
+         */
+        if (target.isSamePerson(editedPerson)) {
+            if (internalList.stream()
+                    .anyMatch(person -> !person.equals(target) && person.isSamePerson(editedPerson))) {
+                throw new DuplicatePersonException();
+            }
         }
 
         internalList.set(index, editedPerson);

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.model.event.exceptions.DuplicateEventException;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 


### PR DESCRIPTION
Issue as follows:

During editing persons, the check is done for `!target.isSamePerson(editedPerson) && contains(editedPerson)`. This does not cover the case whereby 
- `target` and `anotherPerson` have the same names but are different persons (different phone, email, etc.), where `anotherPerson` is another person in the address book.
- `editedPerson` is both the same person as `target` and the same person as `anotherPerson`.

This can happen if we edit just one field of `target` to get `editedPerson`, e.g. let `editedPerson` have the same phone number as `anotherPerson`, and all other details the same as `target`.

As a temporary fix, we can add another check for `editedPerson` being contained in the list of persons, excluding `target`.