### PR TITLE
Add tests and extra condition checking in UniqueEventList

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditEventAddressCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEventAddressCommand.java
@@ -80,6 +80,9 @@ public class EditEventAddressCommand extends Command {
         * unless it is the same event as eventToEdit. Date and time is not edited
         * in this command, so there should not be any existing event with same date/time
         * in the address book, else there is a clashing event.
+        *
+        * Also, as clashing events are not allowed, by Event#isSameEvent, we will also never have the case
+        * whereby editedEvent is the same event as both eventToEdit AND another event in the address book.
         */
         assert (!(!eventToEdit.isSameEvent(editedEvent) && model.hasEvent(editedEvent)));
 

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -12,7 +12,7 @@ import seedu.address.commons.core.GuiSettings;
 public class UserPrefs {
 
     private GuiSettings guiSettings;
-    private Path addressBookFilePath = Paths.get("data" , "eventsPlus.xml");
+    private Path addressBookFilePath = Paths.get("data" , "eventsPlus+.xml");
 
     public UserPrefs() {
         setGuiSettings(500, 500, 0, 0, true, null);

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -129,7 +129,6 @@ public class Event {
                 && eventStartTime.compareTo(event.eventEndTime) < 0;
     }
 
-    //todo: check isSameEvent constraints
     /**
      * Returns true if both events are equal
      */

--- a/src/main/java/seedu/address/model/event/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/event/UniqueEventList.java
@@ -75,6 +75,14 @@ public class UniqueEventList implements Iterable<Event> {
             throw new DuplicateEventException();
         }
 
+        // captures the case where editedEvent is the same event as both target AND another event in internalList
+        if (target.isSameEvent(editedEvent)) {
+            if (internalList.stream()
+                    .anyMatch(event -> !event.equals(target) && event.isSameEvent(editedEvent))) {
+                throw new DuplicateEventException();
+            }
+        }
+
         internalList.set(index, editedEvent);
     }
 

--- a/src/test/java/seedu/address/model/event/EventNameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/event/EventNameContainsKeywordsPredicateTest.java
@@ -1,0 +1,81 @@
+package seedu.address.model.event;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.testutil.ScheduledEventBuilder;
+
+public class EventNameContainsKeywordsPredicateTest {
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        EventNameContainsKeywordsPredicate firstPredicate =
+                new EventNameContainsKeywordsPredicate(firstPredicateKeywordList);
+        EventNameContainsKeywordsPredicate secondPredicate =
+                new EventNameContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        EventNameContainsKeywordsPredicate firstPredicateCopy =
+                new EventNameContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_eventNameContainsKeywords_returnsTrue() {
+        // One keyword
+        EventNameContainsKeywordsPredicate predicate = new EventNameContainsKeywordsPredicate(Collections.singletonList(
+                "Meeting"));
+        assertTrue(predicate.test(new ScheduledEventBuilder().withEventName("Meeting").build()));
+
+        // Multiple keywords
+        predicate = new EventNameContainsKeywordsPredicate(Arrays.asList("Meeting", "Appointment"));
+        assertTrue(predicate.test(new ScheduledEventBuilder().withEventName("Meeting Appointment").build()));
+
+        // Only one matching keyword
+        predicate = new EventNameContainsKeywordsPredicate(Arrays.asList("Meeting", "Class"));
+        assertTrue(predicate.test(new ScheduledEventBuilder().withEventName("Meeting").build()));
+
+        // Mixed-case keywords
+        predicate = new EventNameContainsKeywordsPredicate(Arrays.asList("MEeTing", "ApPOinTmeNt"));
+        assertTrue(predicate.test(new ScheduledEventBuilder().withEventName("Meeting Appointment").build()));
+    }
+
+    @Test
+    public void test_eventNameDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        EventNameContainsKeywordsPredicate predicate = new EventNameContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new ScheduledEventBuilder().withEventName("Meeting").build()));
+
+        // Non-matching keyword
+        predicate = new EventNameContainsKeywordsPredicate(Arrays.asList("Class"));
+        assertFalse(predicate.test(new ScheduledEventBuilder().withEventName("Meeting Appointment").build()));
+
+        // Keywords match event description, address but not name
+        predicate = new EventNameContainsKeywordsPredicate(Arrays.asList("SOCLecture", "testDesc"));
+        assertFalse(predicate.test(new ScheduledEventBuilder()
+                .withEventName("nonmatching name")
+                .withEventDescription("testDesc")
+                .withEventAddress("SOCLecture")
+                .build()));
+    }
+}


### PR DESCRIPTION
Additional checks for `editedEvent` being same event (but not equals to) as `target` and `anotherEvent`, where `anotherEvent` is another event in the EventsPlus+ but is not the same as `target`